### PR TITLE
Safari and IE flex bug – fixes #6

### DIFF
--- a/dist/gridly-col-widths.min.css
+++ b/dist/gridly-col-widths.min.css
@@ -1,1 +1,1 @@
-.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}
+@media(min-width:48em){.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}}

--- a/dist/gridly-core.min.css
+++ b/dist/gridly-core.min.css
@@ -1,1 +1,1 @@
-.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 100%}}
+.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 auto}}

--- a/dist/gridly.min.css
+++ b/dist/gridly.min.css
@@ -1,2 +1,2 @@
-.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 100%}}
-.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}
+.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 auto}}
+@media(min-width:48em){.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}}

--- a/lib/gridly-col-widths.css
+++ b/lib/gridly-col-widths.css
@@ -1,5 +1,7 @@
-.col-tenth { flex: 0 0 10%; }
-.col-fifth { flex: 0 0 20%; }
-.col-quarter { flex: 0 0 25%; }
-.col-third { flex: 0 0 33.3333334%; }
-.col-half { flex: 0 0 50%; }
+@media (min-width: 48em) {
+  .col-tenth { flex: 0 0 10%; }
+  .col-fifth { flex: 0 0 20%; }
+  .col-quarter { flex: 0 0 25%; }
+  .col-third { flex: 0 0 33.3333334%; }
+  .col-half { flex: 0 0 50%; }
+}

--- a/lib/gridly.css
+++ b/lib/gridly.css
@@ -2,5 +2,5 @@
 .col { flex: 1; }
 @media (max-width: 48em) {
     .row { flex-direction: column; }
-    .col { flex: 0 0 100%; }
+    .col { flex: 0 0 auto; }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "browsers"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+  "contributors": [
+    "Oliver Pattison <oliverpattison@gmail.com> (http://olivermak.es)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/gridly/issues"


### PR DESCRIPTION
This fixes problematic layout-breaking flex behavior (outlined in detail in #6).

The fix should work in IE 11 and Safari 9.x. This also works in the latest Chrome and Firefox.

Feel free to test it out further. If this fix is good, let me know and I can update docs and contributing information. (First I want to make sure it matches what you’re trying to do here). 

I’ve tried to keep everything as minimal as possible, with only one changed property in core and one media query in gridly-col-widths.css – `min-width: 48em` which is the _reverse_ of the only other media query used in this package.
