### PR TITLE
gridly 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gridly [![Support this project][donate-now]][paypal-donations]
 
-The minimal (~157 bytes) grid system for modern browsers.
+The minimal (~100-170 bytes) grid system for modern browsers.
 
 You don't need monolithic CSS frameworks for simple grid systems. ~150 bytes of CSS can save your life. :dizzy:
 
@@ -77,6 +77,8 @@ Run `npm run release` to recreate all the `dist` files.
 
 ## Where is this library used?
 If you are using this library in one of your projects, add it in this list. :sparkles:
+
+ - [showalicense.com](http://showalicense.com/)–A site to provide an easy way to show licenses and their human-readable explanations. ([source](https://github.com/IonicaBizau/showalicense.com))
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The minimal (~100-170 bytes) grid system for modern browsers.
 
-You don't need monolithic CSS frameworks for simple grid systems. ~150 bytes of CSS can save your life. :dizzy:
+You don't need monolithic CSS frameworks for simple grid systems. ~100 bytes of CSS can save your life. :dizzy:
 
 ## Usage
 
@@ -12,7 +12,7 @@ In the [`dist`](/dist) directory there are three minified files:
 
  - `gridly-core.min.css` (105 B): just the Gridly core including same-width column support and mobile responsive support.
  - `gridly-col-widths.min.css` (92 B): the custom width columns
- - `gridly.min.css` (157 B): the previous two files' content put together
+ - `gridly.min.css` (165 B): the previous two files' content put together
 
 ## :rocket: Available on CDN!
 

--- a/dist/gridly-col-widths.min.css
+++ b/dist/gridly-col-widths.min.css
@@ -1,1 +1,1 @@
-.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}
+@media(min-width:48em){.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}}

--- a/dist/gridly-core.min.css
+++ b/dist/gridly-core.min.css
@@ -1,1 +1,1 @@
-.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 100%}}
+.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 auto}}

--- a/dist/gridly.min.css
+++ b/dist/gridly.min.css
@@ -1,2 +1,2 @@
-.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 100%}}
-.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}
+.row{display:flex}.col{flex:1}@media(max-width:48em){.row{flex-direction:column}.col{flex:0 0 auto}}
+@media(min-width:48em){.col-tenth{flex:0 0 10%}.col-fifth{flex:0 0 20%}.col-quarter{flex:0 0 25%}.col-third{flex:0 0 33.3333334%}.col-half{flex:0 0 50%}}

--- a/lib/gridly-col-widths.css
+++ b/lib/gridly-col-widths.css
@@ -1,5 +1,7 @@
-.col-tenth { flex: 0 0 10%; }
-.col-fifth { flex: 0 0 20%; }
-.col-quarter { flex: 0 0 25%; }
-.col-third { flex: 0 0 33.3333334%; }
-.col-half { flex: 0 0 50%; }
+@media (min-width: 48em) {
+  .col-tenth { flex: 0 0 10%; }
+  .col-fifth { flex: 0 0 20%; }
+  .col-quarter { flex: 0 0 25%; }
+  .col-third { flex: 0 0 33.3333334%; }
+  .col-half { flex: 0 0 50%; }
+}

--- a/lib/gridly.css
+++ b/lib/gridly.css
@@ -2,5 +2,5 @@
 .col { flex: 1; }
 @media (max-width: 48em) {
     .row { flex-direction: column; }
-    .col { flex: 0 0 100%; }
+    .col { flex: 0 0 auto; }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gridly",
   "version": "1.1.0",
-  "description": "The minimal (~157 bytes) grid system for modern browsers.",
+  "description": "The minimal (~100-170 bytes) grid system for modern browsers.",
   "main": "lib/gridly.css",
   "directories": {
     "example": "example"
@@ -136,7 +136,12 @@
     "h_img": "http://i.imgur.com/kPrOESX.png",
     "ex_img": "http://i.imgur.com/m4pwrnO.png",
     "h_url": "http://ionicabizau.github.io/gridly/example/",
-    "ex_url": "http://ionicabizau.github.io/gridly/example/"
+    "ex_url": "http://ionicabizau.github.io/gridly/example/",
+    "usages": {
+        "ul": [
+            "[showalicense.com](http://showalicense.com/)–A site to provide an easy way to show licenses and their human-readable explanations. ([source](https://github.com/IonicaBizau/showalicense.com))"
+        ]
+    }
   },
   "dependencies": {
     "uglifycss": "^0.0.18"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "browsers"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+  "contributors": [
+    "Oliver Pattison <oliverpattison@gmail.com> (http://olivermak.es)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/gridly/issues"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "blah": {
     "description": [
       {
-        "p": "You don't need monolithic CSS frameworks for simple grid systems. ~150 bytes of CSS can save your life. :dizzy:"
+        "p": "You don't need monolithic CSS frameworks for simple grid systems. ~100 bytes of CSS can save your life. :dizzy:"
       },
       {
         "h2": "Usage"
@@ -51,7 +51,7 @@
         "ul": [
           "`gridly-core.min.css` (105 B): just the Gridly core including same-width column support and mobile responsive support.",
           "`gridly-col-widths.min.css` (92 B): the custom width columns",
-          "`gridly.min.css` (157 B): the previous two files' content put together"
+          "`gridly.min.css` (165 B): the previous two files' content put together"
         ]
       },
       { "h2": ":rocket: Available on CDN!" },


### PR DESCRIPTION
- This fixes problematic layout-breaking flex behavior (outlined in detail in #6). Special thanks to @opattison! :cake: 
  
  The fix should work in IE 11 and Safari 9.x.
- Added [`showalicense.com`](http://showalicense.com/) as example of website where Gridly is used. :memo: 
- Updated the description (now, the entire thing–minimized and gzipped–weights 165B while the core weights ~105B).
