### PR TITLE
gridly 1.3.0: improved example, bag.css

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -9,7 +9,7 @@
         <title>Gridly</title>
     </head>
     <body>
-        <div class="container">
+        <div class="fixed bag">
             <section class="title-section text-center">
                 <h1 class="title">Gridly</h1>
                 <p>The minimal grid system.</p>
@@ -42,13 +42,13 @@
                 </div>
                 <div class="row">
                     <div class="col col-half">
-                        <div class="content">column-half</div>
+                        <div class="content">1 / 2</div>
                     </div>
                     <div class="col col-quarter">
-                        <div class="content">column-quarter</div>
+                        <div class="content">1 / 4</div>
                     </div>
                     <div class="col col-quarter">
-                        <div class="content">column-quarter</div>
+                        <div class="content">1 / 4</div>
                     </div>
                 </div>
                 <div class="row">

--- a/example/style.css
+++ b/example/style.css
@@ -1,5 +1,6 @@
 /* some custom css for the example page */
 @import url(https://fonts.googleapis.com/css?family=Ubuntu:400,700);
+@import url(https://cdn.rawgit.com/IonicaBizau/bag.css/gh-pages/dist/bag.fixed.css);
 
 body {
     font-family: 'Ubuntu', sans-serif;
@@ -7,18 +8,14 @@ body {
     background-color: #ecf0f1;
 }
 
-.container {
-    max-width: 960px;
-    width: 100%;
-    margin: 40px auto;
+.bag.fixed {
     background-color: #fff;
-    padding-bottom: 1em;
 }
-
 
 section.title-section .col {
     padding: 10px;
 }
+
 section.title-section.text-center {
     text-align: center;
     padding: 4em;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridly",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The minimal (~100-170 bytes) grid system for modern browsers.",
   "main": "lib/gridly.css",
   "directories": {


### PR DESCRIPTION
- Improved the example page fixing the padding/margin issue (see #10). Thanks @burakcan! :cake: 
- Replaced the custom `.container` implementation with [`bag.css`](https://github.com/IonicaBizau/bag.css)–a CSS library I open-sourced today–that will take care of the fixed & responsive grid. :triangular_ruler: 
