### PR TITLE
gridly 1.4.8

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-16 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
+Copyright (c) 2015-17 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # gridly
 
- [![Patreon](https://img.shields.io/badge/Support%20me%20on-Patreon-%23e6461a.svg)][patreon] [![Buy](https://img.shields.io/badge/%24-buy-1abc9c.svg)](https://market.bloggify.org/2-gridly) [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/gridly.svg)](https://www.npmjs.com/package/gridly) [![Downloads](https://img.shields.io/npm/dt/gridly.svg)](https://www.npmjs.com/package/gridly) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/gridly.svg)](https://www.npmjs.com/package/gridly) [![Downloads](https://img.shields.io/npm/dt/gridly.svg)](https://www.npmjs.com/package/gridly) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > The minimal (~100-170 bytes) grid system for modern browsers.
 
@@ -103,16 +103,6 @@ Like specified above, the `gridly.min.css` contains both: the core and the custo
 Have an idea? Found a bug? See [how to contribute][contributing].
 
 
-## :moneybag: Donations
-
-Another way to support the development of my open-source modules is
-to [set up a recurring donation, via Patreon][patreon]. :rocket:
-
-[PayPal donations][paypal-donations] are appreciated too! Each dollar helps.
-
-Thanks! :heart:
-
-
 Run `npm i` to install the dependencies. Then, you can run the npm scripts using `npm run <script-name>`.
 
 
@@ -131,13 +121,10 @@ If you are using this library in one of your projects, add it in this list. :spa
 
 [MIT][license] © [Ionică Bizău][website]
 
-[patreon]: https://www.patreon.com/ionicabizau
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW
 [donate-now]: http://i.imgur.com/6cMbHOC.png
 
-
 [license]: http://showalicense.com/?fullname=Ionic%C4%83%20Biz%C4%83u%20%3Cbizauionica%40gmail.com%3E%20(http%3A%2F%2Fionicabizau.net)&year=2015#license-mit
-
 [website]: http://ionicabizau.net
 [contributing]: /CONTRIBUTING.md
 [docs]: /DOCUMENTATION.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridly",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "The minimal (~100-170 bytes) grid system for modern browsers.",
   "main": "lib/gridly.css",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -170,9 +170,6 @@
     },
     "buy": "https://market.bloggify.org/2-gridly"
   },
-  "dependencies": {
-    "uglifycss": "^0.0.18"
-  },
   "files": [
     "bin/",
     "app/",


### PR DESCRIPTION
Remove uglifycss from dependencies. Keep it in `devDependencies` only. Fixed #19.